### PR TITLE
Add Lighter trading bot example

### DIFF
--- a/back.py
+++ b/back.py
@@ -1,0 +1,92 @@
+import asyncio
+import pandas as pd
+
+from config import CONFIG, STOP_LOSS_PCT
+from lighter_client import LighterClient
+from indicators import (
+    compute_rsi,
+    compute_bollinger,
+    get_csi,
+    compute_csc,
+    check_signal,
+)
+
+
+async def fetch_history(client: LighterClient, total_bars: int = 100000) -> pd.DataFrame:
+    limit = 1000
+    end = None
+    dfs = []
+    while len(dfs) * limit < total_bars:
+        df = await client.fetch_candles(count_back=limit, end_time=end)
+        if df.empty:
+            break
+        dfs.append(df)
+        end = int(df["timestamp"].iloc[0].value / 1e6) - 1
+    full = pd.concat(dfs).drop_duplicates("timestamp").sort_values("timestamp")
+    return full.reset_index(drop=True)
+
+
+async def run_backtest():
+    client = LighterClient()
+    df = await fetch_history(client)
+    df = compute_rsi(df)
+    df = compute_bollinger(df)
+    df = get_csi(df)
+    df = compute_csc(df, CONFIG["min_cluster"], CONFIG["bull_quant"], CONFIG["bear_quant"])
+
+    signals = [None]
+    for i in range(1, len(df)):
+        signals.append(check_signal(df.iloc[i], df.iloc[i - 1]))
+    df["signal"] = signals
+
+    in_position = False
+    entry_price = entry_idx = None
+    pos_type = None
+    trades = []
+
+    for i in range(1, len(df)):
+        row = df.iloc[i]
+        sig = row["signal"]
+        if not in_position and sig in ["buy", "sell"]:
+            in_position = True
+            entry_idx = i
+            entry_price = row["close"]
+            pos_type = "long" if sig == "buy" else "short"
+            stop_price = (
+                entry_price * (1 - STOP_LOSS_PCT)
+                if pos_type == "long"
+                else entry_price * (1 + STOP_LOSS_PCT)
+            )
+        elif in_position:
+            exit_idx = entry_idx + 15
+            hit_stop = (
+                row["low"] <= stop_price if pos_type == "long" else row["high"] >= stop_price
+            )
+            if hit_stop or i >= exit_idx:
+                exit_price = stop_price if hit_stop else row["close"]
+                pnl = (
+                    (exit_price - entry_price) / entry_price * 100
+                    if pos_type == "long"
+                    else (entry_price - exit_price) / entry_price * 100
+                )
+                trades.append(
+                    {
+                        "entry_time": df.iloc[entry_idx]["timestamp"],
+                        "exit_time": row["timestamp"],
+                        "side": pos_type,
+                        "entry_price": entry_price,
+                        "exit_price": exit_price,
+                        "pnl_%": pnl,
+                        "reason": "stop_loss" if hit_stop else "time_exit",
+                    }
+                )
+                in_position = False
+
+    tdf = pd.DataFrame(trades)
+    tdf.to_csv("trades_complete.csv", sep=";", index=False)
+    print(tdf.tail(10))
+    print("Total PnL:", round(tdf["pnl_%"].sum(), 2), "%")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_backtest())

--- a/config.py
+++ b/config.py
@@ -1,0 +1,20 @@
+BASE_URL = "https://mainnet.zklighter.elliot.ai"
+PRIVATE_KEY = "YOUR_PRIVATE_KEY"
+ACCOUNT_INDEX = 0
+API_KEY_INDEX = 0
+
+MARKET_ID = 0  # ETH/USDC market id per docs
+RESOLUTION = "5m"
+BB_PERIOD = 40
+BB_STD = 1
+STOP_LOSS_PCT = 0.004
+TRADE_QTY = 1
+EXIT_AFTER_BARS = 3
+
+CONFIG = {
+    "min_cluster": 3,
+    "bull_quant": 0.75,
+    "bear_quant": 0.25,
+    "rsi": 60,
+    "total_bars": 60000,
+}

--- a/indicators.py
+++ b/indicators.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pandas as pd
+from scipy.stats import zscore
+
+from config import BB_PERIOD, BB_STD, CONFIG
+
+
+def compute_rsi(df: pd.DataFrame, period: int = 450) -> pd.DataFrame:
+    delta = df["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(period, min_periods=1).mean()
+    avg_loss = loss.rolling(period, min_periods=1).mean()
+    rs = avg_gain / avg_loss
+    df["RSI"] = 100 - (100 / (1 + rs))
+    df["RSI"] = df["RSI"].fillna(method="bfill")
+    return df
+
+
+def compute_bollinger(df: pd.DataFrame) -> pd.DataFrame:
+    df["ma"] = df["close"].rolling(BB_PERIOD).mean()
+    df["std"] = df["close"].rolling(BB_PERIOD).std()
+    df["upper"] = df["ma"] + BB_STD * df["std"]
+    df["lower"] = df["ma"] - BB_STD * df["std"]
+    return df
+
+
+def get_csi(df: pd.DataFrame) -> pd.DataFrame:
+    body = (df["close"] - df["open"]).abs()
+    rng = (df["high"] - df["low"]).replace(0, np.nan)
+    body_ratio = body / rng
+    direction = np.where(df["close"] > df["open"], 1, -1)
+    vol_score = df["volume"] / df["volume"].rolling(50).max()
+    range_z = zscore(df["high"] - df["low"]).clip(-3, 3)
+
+    tr = pd.DataFrame({
+        "hl": df["high"] - df["low"],
+        "hc": (df["high"] - df["close"].shift(1)).abs(),
+        "lc": (df["low"] - df["close"].shift(1)).abs(),
+    }).max(axis=1)
+
+    atr = tr.rolling(14).mean().bfill()
+    df["CSI"] = direction * (0.5 * body_ratio + 0.3 * vol_score + 0.2 * range_z) / atr
+    return df
+
+
+def compute_csc(df: pd.DataFrame, min_cluster: int, bull_q: float, bear_q: float) -> pd.DataFrame:
+    bull_thr = df["CSI"].quantile(bull_q)
+    bear_thr = df["CSI"].quantile(bear_q)
+    df["sentiment"] = np.where(
+        df["CSI"] >= bull_thr,
+        "bull",
+        np.where(df["CSI"] <= bear_thr, "bear", "neutral"),
+    )
+    df["cluster_id"] = pd.Series(dtype="object")
+    curr_type, curr_start, length = None, None, 0
+    for i, s in df["sentiment"].items():
+        if s == curr_type and s in ["bull", "bear"]:
+            length += 1
+        else:
+            if curr_type in ["bull", "bear"] and length >= min_cluster:
+                df.loc[curr_start : i - 1, "cluster_id"] = f"{curr_type}_{curr_start}"
+            if s in ["bull", "bear"]:
+                curr_type, curr_start, length = s, i, 1
+            else:
+                curr_type, length = None, 0
+    if curr_type in ["bull", "bear"] and length >= min_cluster:
+        df.loc[curr_start : df.index[-1], "cluster_id"] = f"{curr_type}_{curr_start}"
+    return df
+
+
+def check_signal(row: pd.Series, prev_row: pd.Series):
+    if np.isnan(row["lower"]) or np.isnan(prev_row["CSI"]) or np.isnan(row["CSI"]):
+        return None
+    cluster = row["cluster_id"]
+    if not isinstance(cluster, str):
+        return None
+    long_cond = (
+        row["close"] < row["lower"]
+        and row["CSI"] > 0
+        and row["CSI"] > prev_row["CSI"]
+        and cluster.startswith("bull")
+        and row["RSI"] < CONFIG["rsi"]
+    )
+    short_cond = (
+        row["close"] > row["upper"]
+        and row["CSI"] < 0
+        and row["CSI"] < prev_row["CSI"]
+        and cluster.startswith("bear")
+        and row["RSI"] > (100 - CONFIG["rsi"])
+    )
+    if long_cond:
+        return "buy"
+    if short_cond:
+        return "sell"
+    return None

--- a/lighter_client.py
+++ b/lighter_client.py
@@ -1,0 +1,79 @@
+import time
+from typing import Optional
+
+import pandas as pd
+
+from lighter.configuration import Configuration
+from lighter.api_client import ApiClient
+from lighter.api import CandlestickApi
+from lighter.signer_client import SignerClient
+
+from config import (
+    BASE_URL,
+    PRIVATE_KEY,
+    ACCOUNT_INDEX,
+    API_KEY_INDEX,
+    MARKET_ID,
+    RESOLUTION,
+)
+
+_INTERVAL_MS = {
+    "1m": 60_000,
+    "5m": 5 * 60_000,
+    "1h": 60 * 60_000,
+}
+
+
+class LighterClient:
+    """Wrapper around official lighter-sdk APIs."""
+
+    def __init__(self):
+        cfg = Configuration(host=BASE_URL)
+        self.api_client = ApiClient(cfg)
+        self.candle_api = CandlestickApi(self.api_client)
+        self.signer = SignerClient(
+            url=BASE_URL,
+            private_key=PRIVATE_KEY,
+            api_key_index=API_KEY_INDEX,
+            account_index=ACCOUNT_INDEX,
+        )
+
+    async def fetch_candles(self, count_back: int = 1000, end_time: Optional[int] = None) -> pd.DataFrame:
+        """Download OHLCV candlesticks."""
+        if end_time is None:
+            end_time = int(time.time() * 1000)
+        interval = _INTERVAL_MS[RESOLUTION]
+        start = end_time - count_back * interval
+        resp = await self.candle_api.candlesticks(
+            market_id=MARKET_ID,
+            resolution=RESOLUTION,
+            start_timestamp=start,
+            end_timestamp=end_time,
+            count_back=count_back,
+            set_timestamp_to_end=True,
+        )
+        data = [
+            [c.timestamp, c.open, c.high, c.low, c.close, c.volume]
+            for c in resp.candlesticks
+        ]
+        df = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+        df[["open", "high", "low", "close", "volume"]] = df[["open", "high", "low", "close", "volume"]].astype(float)
+        df = df.sort_values("timestamp").reset_index(drop=True)
+        return df
+
+    async def create_market_order(self, side: str, base_amount: float, avg_price: float):
+        """Place market order via SignerClient."""
+        is_ask = side.lower() == "sell"
+        client_order_index = int(time.time() * 1000)
+        tx, tx_hash, error = await self.signer.create_market_order(
+            market_index=MARKET_ID,
+            client_order_index=client_order_index,
+            base_amount=str(base_amount),
+            avg_execution_price=str(avg_price),
+            is_ask=is_ask,
+            reduce_only=False,
+        )
+        if error:
+            raise RuntimeError(error)
+        return tx_hash

--- a/main.py
+++ b/main.py
@@ -1,0 +1,97 @@
+import asyncio
+import datetime
+import time
+from collections import deque
+
+import pandas as pd
+
+from config import (
+    CONFIG,
+    STOP_LOSS_PCT,
+    TRADE_QTY,
+    EXIT_AFTER_BARS,
+)
+from lighter_client import LighterClient
+from indicators import compute_rsi, compute_bollinger, get_csi, compute_csc, check_signal
+
+
+async def fetch_history(client: LighterClient, total_bars: int) -> pd.DataFrame:
+    limit = 1000
+    end = None
+    frames = []
+    while len(frames) * limit < total_bars:
+        df = await client.fetch_candles(count_back=limit, end_time=end)
+        if df.empty:
+            break
+        frames.append(df)
+        end = int(df["timestamp"].iloc[0].value / 1e6) - 1
+    full = pd.concat(frames).drop_duplicates("timestamp").sort_values("timestamp")
+    return full.reset_index(drop=True)
+
+
+async def trading_loop():
+    client = LighterClient()
+    df = await fetch_history(client, CONFIG["total_bars"])
+    entry_history = deque(maxlen=100)
+    open_positions = []
+
+    while True:
+        now = datetime.datetime.utcnow()
+        if now.minute % 5 == 0 and now.second < 5:
+            latest_df = await client.fetch_candles(count_back=2)
+            if len(latest_df) < 2:
+                await asyncio.sleep(1)
+                continue
+            candle = latest_df.iloc[-2]
+            df = pd.concat([df, candle.to_frame().T]).drop_duplicates("timestamp").tail(CONFIG["total_bars"])
+
+            df = compute_bollinger(df)
+            df = get_csi(df)
+            df = compute_csc(df, CONFIG["min_cluster"], CONFIG["bull_quant"], CONFIG["bear_quant"])
+            df = compute_rsi(df)
+            df["signal"] = [None] + [check_signal(df.iloc[i], df.iloc[i - 1]) for i in range(1, len(df))]
+
+            last = df.iloc[-2]
+            signal = last["signal"]
+            if signal in ["buy", "sell"]:
+                entry_time = datetime.datetime.utcnow()
+                if not any((entry_time - t).total_seconds() < 300 and s == signal for t, s in entry_history):
+                    stop_price = last["close"] * (1 - STOP_LOSS_PCT if signal == "buy" else 1 + STOP_LOSS_PCT)
+                    side = "sell" if signal == "sell" else "buy"
+                    try:
+                        await client.create_market_order(side, TRADE_QTY, last["close"])
+                        entry_history.append((entry_time, signal))
+                        open_positions.append({
+                            "type": "long" if signal == "buy" else "short",
+                            "entry_price": last["close"],
+                            "stop_price": stop_price,
+                            "entry_time": entry_time,
+                        })
+                    except Exception as e:
+                        print("Order error", e)
+
+            current_price = last["close"]
+            to_remove = []
+            for pos in open_positions:
+                elapsed = (datetime.datetime.utcnow() - pos["entry_time"]).total_seconds()
+                hit_stop = (
+                    current_price <= pos["stop_price"] if pos["type"] == "long" else current_price >= pos["stop_price"]
+                )
+                if hit_stop or elapsed >= EXIT_AFTER_BARS * 5 * 60:
+                    try:
+                        await client.create_market_order(
+                            "sell" if pos["type"] == "long" else "buy",
+                            TRADE_QTY,
+                            current_price,
+                        )
+                    except Exception as e:
+                        print("Close error", e)
+                    to_remove.append(pos)
+            for p in to_remove:
+                open_positions.remove(p)
+
+        await asyncio.sleep(3)
+
+
+if __name__ == "__main__":
+    asyncio.run(trading_loop())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+lighter-sdk
+pandas
+numpy
+scipy


### PR DESCRIPTION
## Summary
- add config and indicators for Bollinger strategy
- implement LighterClient using official SDK
- provide backtest and live trading scripts for Lighter exchange

## Testing
- `python -m py_compile back.py main.py lighter_client.py indicators.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfeafe7848322b100590473719e0f